### PR TITLE
Add pagination for past tournaments

### DIFF
--- a/app.py
+++ b/app.py
@@ -78,9 +78,13 @@ def logout():
 @app.route('/')
 def index():
     players = session.get('players', [])
+    page = request.args.get('page', 1, type=int)
+    per_page = 3
     conn = get_db()
+    total = conn.execute('SELECT COUNT(*) FROM tournaments').fetchone()[0]
     rows = conn.execute(
-        "SELECT id, name, created_at, data FROM tournaments ORDER BY id DESC"
+        "SELECT id, name, created_at, data FROM tournaments ORDER BY id DESC LIMIT ? OFFSET ?",
+        (per_page, (page - 1) * per_page),
     ).fetchall()
     conn.close()
     tournaments = []
@@ -94,8 +98,15 @@ def index():
                 "players": data.get("players", []),
             }
         )
+    has_next = page * per_page < total
+    has_prev = page > 1
     return render_template(
-        'index.html', players=players, tournaments=tournaments
+        'index.html',
+        players=players,
+        tournaments=tournaments,
+        page=page,
+        has_next=has_next,
+        has_prev=has_prev,
     )
 
 

--- a/static/style.css
+++ b/static/style.css
@@ -448,6 +448,13 @@ tr:last-child td {
   flex-wrap: wrap;
 }
 
+.pagination {
+  margin-top: 1.5rem;
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+}
+
 /* Add Player Form */
 .add-player-form {
   display: flex;

--- a/templates/index.html
+++ b/templates/index.html
@@ -83,6 +83,14 @@
                 </li>
                 {% endfor %}
             </ul>
+            <div class="pagination">
+                {% if has_prev %}
+                <a href="{{ url_for('index', page=page-1) }}" class="styled-button secondary-button">Previous</a>
+                {% endif %}
+                {% if has_next %}
+                <a href="{{ url_for('index', page=page+1) }}" class="styled-button secondary-button">Next</a>
+                {% endif %}
+            </div>
             {% else %}
             <p>No tournaments saved.</p>
             {% endif %}


### PR DESCRIPTION
## Summary
- show only 3 tournaments per page
- provide Previous/Next buttons to navigate past tournaments
- style pagination links

## Testing
- `python -m py_compile app.py`
- `python -m py_compile tournament.py`


------
https://chatgpt.com/codex/tasks/task_e_6881678a0cf88324a39201debe4d6ff4